### PR TITLE
Add Dockerfile for Interop Testing in OpenShift CI

### DIFF
--- a/dockerfiles/interop/Dockerfile
+++ b/dockerfiles/interop/Dockerfile
@@ -1,0 +1,23 @@
+FROM cypress/base:latest
+
+# Update container and install unzip
+RUN apt -y update && apt install -y unzip
+
+# Create /tmp/windup-ui-tests, copy this repo in to the container and install required Node packages
+RUN mkdir /tmp/windup-ui-tests
+WORKDIR /tmp/windup-ui-tests
+COPY . .
+RUN npm install && npm install cypress-mochawesome-reporter
+
+# Unzip all zip files in /tmp/windup-ui-tests/cypress/fixtures/applications
+WORKDIR /tmp/windup-ui-tests/cypress/fixtures/applications
+RUN unzip '*.zip'
+
+# Set WORKDIR to /tmp/windup-ui-tests
+WORKDIR /tmp/windup-ui-tests
+
+# Set required permissions for OpenShift usage
+RUN chgrp -R 0 /tmp && \
+    chmod -R g=u /tmp
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
**Related Issues**:
- [INTEROP-6860 OCP CI MTR Scenario - Refactor ](https://issues.redhat.com/browse/INTEROP-6860)

## Purpose

This pull request is necessary for interop testing of the MTR operator in OpenShift CI. The Dockerfile created in this pull request is to be used to execute the tests properly.

Please let me know if there is anything else needed on my end.