### PR TITLE
[RFR] added conditional skip functionality to skip case on OCP + disable video

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -18,6 +18,7 @@ module.exports = defineConfig({
     viewportWidth: 1920,
     viewportHeight: 1080,
     reporter: "cypress-multi-reporters",
+    video: false,
     reporterOptions: {
         reporterEnabled: "cypress-mochawesome-reporter, mocha-junit-reporter",
         cypressMochawesomeReporterReporterOptions: {

--- a/cypress/e2e/models/analysis.ts
+++ b/cypress/e2e/models/analysis.ts
@@ -92,7 +92,6 @@ export class Analysis {
             });
     }
 
-    
     search(searchTerm: string): void {
         // Function to Search an analysis by id
         cy.wait(SEC);
@@ -121,7 +120,6 @@ export class Analysis {
             expect(texts).to.deep.eq(texts.sort());
         });
     }
-
 
     deleteLatest(cancel = false): void {
         cy.wait(SEC);

--- a/cypress/e2e/tests/analysis.test.ts
+++ b/cypress/e2e/tests/analysis.test.ts
@@ -1,10 +1,16 @@
 /// <reference types="Cypress" />
 /// <reference types='cypress-tags' />
 
-import { getRandomApplicationData, login, trimAppNames } from "../../utils/utils";
+import {
+    getRandomApplicationData,
+    isInstalledOnOCP,
+    login,
+    trimAppNames,
+} from "../../utils/utils";
 import { Analysis } from "../models/analysis";
 import { Projects } from "../models/projects";
 import { completed } from "../types/constants";
+import { skipOn } from "@cypress/skip-test";
 
 describe(["tier1"], "Analysis", function () {
     beforeEach("Login", function () {
@@ -62,6 +68,7 @@ describe(["tier1"], "Analysis", function () {
     });
 
     it("Analysis for Complete Duke with SourceMode", function () {
+        skipOn(isInstalledOnOCP());
         let projectData = getRandomApplicationData(this.projectData["complete-duke_SM"]);
         const project = new Projects(projectData);
         project.create();

--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -179,3 +179,9 @@ export function enableOption(option: string): void {
     click(optionSelector);
     cy.wait(SEC);
 }
+
+export function isInstalledOnOCP(): boolean {
+    if (windupUiUrl.includes("localhost")) return false;
+
+    return true;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
                 "format": "^0.2.2"
             },
             "devDependencies": {
+                "@cypress/skip-test": "^2.6.1",
                 "@types/cypress": "^1.1.3",
                 "@types/jest": "^29.2.4",
                 "cypress-multi-reporters": "^1.6.2",
@@ -1931,6 +1932,12 @@
             "engines": {
                 "node": ">= 6"
             }
+        },
+        "node_modules/@cypress/skip-test": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/@cypress/skip-test/-/skip-test-2.6.1.tgz",
+            "integrity": "sha512-X+ibefBiuOmC5gKG91wRIT0/OqXeETYvu7zXktjZ3yLeO186Y8ia0K7/gQUpAwuUi28DuqMd1+7tBQVtPkzbPA==",
+            "dev": true
         },
         "node_modules/@cypress/xvfb": {
             "version": "1.2.4",
@@ -8347,6 +8354,12 @@
                 "tunnel-agent": "^0.6.0",
                 "uuid": "^8.3.2"
             }
+        },
+        "@cypress/skip-test": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/@cypress/skip-test/-/skip-test-2.6.1.tgz",
+            "integrity": "sha512-X+ibefBiuOmC5gKG91wRIT0/OqXeETYvu7zXktjZ3yLeO186Y8ia0K7/gQUpAwuUi28DuqMd1+7tBQVtPkzbPA==",
+            "dev": true
         },
         "@cypress/xvfb": {
             "version": "1.2.4",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     },
     "homepage": "https://github.com/windup/windup-ui-tests#readme",
     "devDependencies": {
+        "@cypress/skip-test": "^2.6.1",
         "@types/cypress": "^1.1.3",
         "@types/jest": "^29.2.4",
         "cypress-multi-reporters": "^1.6.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "target": "es5",
         "lib": ["es5", "dom"],
-        "types": ["cypress", "node", "cypress-tags"]
+        "types": ["cypress", "node", "cypress-tags", "@cypress/skip-test"]
     },
     "include": ["*.ts", "**/*.js", "cypress/support/*.ts"]
 }


### PR DESCRIPTION
This PR adds the conditional skip functionality to the framework using @cypress/skip-tests

Using the same, skipping the server path Test case when the tests are triggered on Openshift so that we do not see that 1 irrelevant failure in the test results.

Also, disabled video compression from cypress config, which takes extra time unnecessarily.