### PR TITLE
[RFR] automated mta-239

### DIFF
--- a/cypress/e2e/models/projects.ts
+++ b/cypress/e2e/models/projects.ts
@@ -106,7 +106,7 @@ export class Projects {
     }
 
     //Function to click on "Create wizard"
-    protected openCreateWizard(): void {
+    openCreateWizard(): void {
         cy.contains(primaryButton, createProject, { timeout: 20000 }).should("be.enabled").click();
     }
 

--- a/cypress/e2e/tests/features.test.ts
+++ b/cypress/e2e/tests/features.test.ts
@@ -1,0 +1,43 @@
+/// <reference types="Cypress" />
+/// <reference types='cypress-tags' />
+
+import { skipOn } from "@cypress/skip-test";
+import {
+    getRandomApplicationData,
+    isInstalledOnOCP,
+    isMTROnOCP,
+    login,
+    navigateTo,
+    trimAppNames,
+} from "../../utils/utils";
+import { Projects } from "../models/projects";
+import { completed, projects, SEC } from "../types/constants";
+
+describe(["tier2"], "Features", function () {
+    beforeEach("Login", function () {
+        cy.fixture("json/data").then(function (projectData) {
+            this.projectData = projectData;
+        });
+
+        login();
+    });
+
+    it("MTA-239: Validate azure-aks target not present in MTR", function () {
+        skipOn(isMTROnOCP());
+        let projectData = getRandomApplicationData(this.projectData["JakartaEE9"]);
+        const project = new Projects(projectData);
+        navigateTo(projects);
+        project.openCreateWizard();
+        project.enterProjectDetails(projectData["name"], projectData["desc"]);
+        project.addApplications(projectData["apps"]);
+        cy.contains("h4", "Azure", { timeout: 120 * SEC });
+        //Checking if the dropdown for multiple azure target exists with default value set as azure-appservice.
+        //It should not exist in downstream
+        cy.contains("span", "azure-appservice", { timeout: 120 * SEC }).should("not.exist");
+    });
+
+    after("Teardown", function () {
+        login();
+        Projects.deleteAllProjects();
+    });
+});

--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -185,3 +185,9 @@ export function isInstalledOnOCP(): boolean {
 
     return true;
 }
+
+export function isMTROnOCP(): boolean {
+    if (windupUiUrl.includes("mtr")) return true;
+
+    return false;
+}


### PR DESCRIPTION
This PR automates the mta-239 test case in polarion.

It verifies that azure-aks is not present in downstream by validating that azure-appservice dropdown is not present.