### PR TITLE
[RFR] fixed condition

### DIFF
--- a/cypress/e2e/tests/features.test.ts
+++ b/cypress/e2e/tests/features.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="Cypress" />
 /// <reference types='cypress-tags' />
 
-import { skipOn } from "@cypress/skip-test";
+import { onlyOn, skipOn } from "@cypress/skip-test";
 import {
     getRandomApplicationData,
     isInstalledOnOCP,
@@ -13,7 +13,7 @@ import {
 import { Projects } from "../models/projects";
 import { completed, projects, SEC } from "../types/constants";
 
-describe(["tier2"], "Features", function () {
+describe(["special"], "Features", function () {
     beforeEach("Login", function () {
         cy.fixture("json/data").then(function (projectData) {
             this.projectData = projectData;
@@ -23,7 +23,7 @@ describe(["tier2"], "Features", function () {
     });
 
     it("MTA-239: Validate azure-aks target not present in MTR", function () {
-        skipOn(isMTROnOCP());
+        onlyOn(isMTROnOCP());
         let projectData = getRandomApplicationData(this.projectData["JakartaEE9"]);
         const project = new Projects(projectData);
         navigateTo(projects);
@@ -37,6 +37,7 @@ describe(["tier2"], "Features", function () {
     });
 
     after("Teardown", function () {
+        if (!isMTROnOCP()) return;
         login();
         Projects.deleteAllProjects();
     });


### PR DESCRIPTION
This PR has 2 changes:

1. The test case should not be skipped on MTR. It should be executed only on MTR.

2. As there is currently only 1 test case in the file, Teardown will fail in case of windup as the case is skipped and nothing is there to cleanup. 
So, until another case is added to the file, "Delete project" is moved to the case itself.

Once we add more cases to this file, will add the Teardown as a common function as it is there in other files.

