### PR TITLE
[LPTOCPCI-100] Fix Permissions of Cypress Install in Dockerfile

### DIFF
--- a/dockerfiles/interop/Dockerfile
+++ b/dockerfiles/interop/Dockerfile
@@ -1,13 +1,23 @@
-FROM cypress/base:latest
+FROM docker.io/cypress/included:12.7.0
+
+# point Cypress at the /tmp/cache no matter what user account is used
+# see https://on.cypress.io/caching
+ENV CYPRESS_CACHE_FOLDER=/tmp/.cache/Cypress
+ENV npm_config_cache=/tmp/.cache/npm
 
 # Update container and install unzip
-RUN apt -y update && apt install -y unzip
+RUN apt -y update && \
+    apt install -y unzip
 
 # Create /tmp/windup-ui-tests, copy this repo in to the container and install required Node packages
 RUN mkdir /tmp/windup-ui-tests
 WORKDIR /tmp/windup-ui-tests
 COPY . .
-RUN npm install && npm install cypress-mochawesome-reporter
+RUN npm install && \
+    npm install cypress-mochawesome-reporter \
+    cypress-tags \
+    cypress \
+    cypress-multi-reporters
 
 # Unzip all zip files in /tmp/windup-ui-tests/cypress/fixtures/applications
 WORKDIR /tmp/windup-ui-tests/cypress/fixtures/applications
@@ -17,7 +27,10 @@ RUN unzip '*.zip'
 WORKDIR /tmp/windup-ui-tests
 
 # Set required permissions for OpenShift usage
-RUN chgrp -R 0 /tmp && \
+RUN mkdir -p /.config && \
+    chgrp -R 0 /.config && \
+    chmod -R g=u /.config && \
+    chgrp -R 0 /tmp && \
     chmod -R g=u /tmp
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
We need to make the Cypress install globally available for the pod in OpenShift to use it.