### PR TITLE
[RFR] v1.0 - updated interop test to make it story-points free

### DIFF
--- a/cypress/e2e/tests/targets.test.ts
+++ b/cypress/e2e/tests/targets.test.ts
@@ -16,7 +16,16 @@ describe(["tier1"], "Analysis on different targets", function () {
         login();
     });
 
-    it(["interop"], "Analysis for target Jakarta EE 9", function () {
+    it(["interop"], "Analysis for target eap7", function () {
+        let projectData = getRandomApplicationData(this.projectData["BasicApp_eap7"]);
+        const project = new Projects(projectData);
+        project.create();
+        const analysis = new Analysis(projectData["name"]);
+        analysis.runAnalysis();
+        analysis.verifyLatestAnalysisStatus(completed);
+    });
+
+    it("Analysis for target Jakarta EE 9", function () {
         let projectData = getRandomApplicationData(this.projectData["JakartaEE9"]);
         const project = new Projects(projectData);
         project.create();


### PR DESCRIPTION
As the story points changed in z-stream, it can cause the interop tests to fail.
So, to keep the interop tests story points independent, added a separate test for interop for target eap7.