### PR TITLE
[RFR] fixed source selction issue

### DIFF
--- a/cypress/e2e/models/projects.ts
+++ b/cypress/e2e/models/projects.ts
@@ -225,8 +225,10 @@ export class Projects {
                 advancedOptions.sources.forEach((source) => {
                     inputText(inputSources, source);
                     clickByText("button", source);
+                    click(inputSources);
                 });
             }
+            cy.wait(10 * SEC);
             if (advancedOptions.options)
                 advancedOptions.options.forEach((option) => enableOption(option));
         }


### PR DESCRIPTION
After selecting one source, the list of sources remain visible to select more issues, which was interfering with enabling other advanced options. So, had to click on the input once to close the list.