### PR TITLE
[main Branch] Fix interop Docker image

### DIFF
--- a/dockerfiles/interop/Dockerfile
+++ b/dockerfiles/interop/Dockerfile
@@ -5,9 +5,17 @@ FROM docker.io/cypress/included:12.7.0
 ENV CYPRESS_CACHE_FOLDER=/tmp/.cache/Cypress
 ENV npm_config_cache=/tmp/.cache/npm
 
-# Update container and install unzip
-RUN apt -y update && \
-    apt install -y unzip
+# Must remove the Google Chrome repository because there is a missing GPG key and it causes the build to fail
+# Then run "apt update" and instal gnupg to add the missing GPG key for Google Chrome
+# Then re-add the Google Chrome repository
+# After fixing the GPG issue, we can install unzip (the only reason all of that had to be done...)
+RUN echo "" > /etc/apt/sources.list.d/google-chrome.list \
+    && apt -y update \
+    && apt install -y gnupg \
+    && echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
+    && wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && apt -y update \
+    && apt install -y unzip
 
 # Create /tmp/windup-ui-tests, copy this repo in to the container and install required Node packages
 RUN mkdir /tmp/windup-ui-tests

--- a/dockerfiles/interop/Dockerfile
+++ b/dockerfiles/interop/Dockerfile
@@ -5,15 +5,9 @@ FROM docker.io/cypress/included:12.7.0
 ENV CYPRESS_CACHE_FOLDER=/tmp/.cache/Cypress
 ENV npm_config_cache=/tmp/.cache/npm
 
-# Must remove the Google Chrome repository because there is a missing GPG key and it causes the build to fail
-# Then run "apt update" and instal gnupg to add the missing GPG key for Google Chrome
-# Then re-add the Google Chrome repository
-# After fixing the GPG issue, we can install unzip (the only reason all of that had to be done...)
+# Must remove the Google Chrome repository to run apt update/install because the GPG is missing.
+# Install unzip
 RUN echo "" > /etc/apt/sources.list.d/google-chrome.list \
-    && apt -y update \
-    && apt install -y gnupg \
-    && echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
-    && wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && apt -y update \
     && apt install -y unzip
 


### PR DESCRIPTION
Had to update the RUN command that installs unzip. The Google Chrome repository in the image is missing a GPG key. Need to remove the repository before running `apt update` so that the image build doesn't fail.